### PR TITLE
fix: Fixes #12. Update tx list page to show transactions to all contracts and self-transactions

### DIFF
--- a/src/components/Transactions/helpers/index.tsx
+++ b/src/components/Transactions/helpers/index.tsx
@@ -41,6 +41,7 @@ const fromTo = R.curry(
   }
 )
 
+// Example: https://kovan.etherscan.io/tx/0xa8e71ff560ccbf3e231817d43ea76cdac2fa9e515f7fea40ea31bb83540250af
 const isContractInteraction = (transaction: EtherscanTransaction): boolean =>
   transaction.value === '0' && transaction.input !== '0x'
 
@@ -91,14 +92,90 @@ export const parseEtherscanReply = R.curry(
     R.map(parseEtherscanTransaction(address))(etherscanResult)
 )
 
+const ETHERSCAN_API_KEY = 'GKBJXUY561Q8URUJPXQKAGPACWQU1D1GEN';
+
+/**
+ * Return all transactions for a given address and network
+ *
+ * Example: https://api-kovan.etherscan.io/api?module=account&action=txlist&address=0x6b9b2c4f6f92cc37cfe61f910c80e40b37206306&sort=desc&apikey=GKBJXUY561Q8URUJPXQKAGPACWQU1D1GEN
+ * Reference: Etherscan Accounts API https://etherscan.io/apis#accounts
+ *
+ * @param address Account or contract address
+ * @param network Ethereum network ID
+ */
 export const getTransactions = async (
   address: string,
   network: number
 ): Promise<TransactionProps[]> => {
+  const moduleKind = 'account'
+  const actionKind = 'txlist'
   const response = await request(
     `https://api${
       network === 42 ? '-kovan' : ''
-    }.etherscan.io/api?module=account&action=txlist&address=${address}&sort=desc&apikey=GKBJXUY561Q8URUJPXQKAGPACWQU1D1GEN`
+    }.etherscan.io/api?module=${moduleKind}&action=${actionKind}&address=${
+      address
+    }&sort=desc&apikey=${ETHERSCAN_API_KEY}`
   )
   return parseEtherscanReply(address, R.path(['body', 'result'])(response))
+}
+
+/**
+ * Return whether the given recipient of a transaction is a contract address (not an account address)
+ *
+ * Example: https://api-kovan.etherscan.io/api?module=contract&action=getabi&address=0x17a92021aA6304C05E3f6D7D45969C0B73E3516B&apikey=GKBJXUY561Q8URUJPXQKAGPACWQU1D1GEN
+ * Reference: Etherscan Contracts API https://etherscan.io/apis#contracts
+ *
+ * @param address Account or contract address
+ * @param network Ethereum network ID
+ */
+export const isRecipientContract = async (
+  address: string,
+  network: number
+): Promise<any> => {
+  const moduleKind = 'contract'
+  const actionKind = 'getabi'
+  try {
+    const { body: etherscanReply } = await request(
+      `https://api${
+        network === 42 ? '-kovan' : ''
+      }.etherscan.io/api?module=${moduleKind}&action=${actionKind}&address=${
+        address
+      }&apikey=${ETHERSCAN_API_KEY}`
+    )
+    return etherscanReply.status === '1' ? true : false
+  } catch (error) {
+    return false
+  }
+}
+
+/*
+ * Modify the transaction properties if transaction sent to yourself or if recipient is a contract.
+ *
+ * If the transaction recipient is found to be a contract address then the transaction is labelled
+ * as a contract interaction by setting the transaction's `isRecipientContract` property value to true.
+ * If the transaction recipient is found to be the sender's address then the transaction's
+ * `isRecipientSender` property value is set to true.
+ *
+ * @param txs     Transactions list
+ * @param address Account or contract address
+ * @param network Ethereum network ID
+ */
+export const tweakTxs = async (
+  txs: any[],
+  address: string,
+  network: number
+): Promise<any> => {
+  return Promise.all(txs.map(async (tx: TransactionProps) => {
+    if (!tx || !tx.fromTo) {
+      return tx
+    }
+    // Example: https://kovan.etherscan.io/tx/0xfabbedf4ed3e70c0b66f7d8ac1530f8636a41a3972f161871090f2d4465d9c85
+    if (await isRecipientContract(tx.fromTo, network) === true) {
+      tx.type = 'contract-interaction'
+    }
+    if (address === tx.fromTo) {
+      tx.type = 'self-interaction'
+    }
+    return tx
+  }))
 }

--- a/src/components/Transactions/saga.tsx
+++ b/src/components/Transactions/saga.tsx
@@ -2,17 +2,20 @@
 import { call, put, select } from 'redux-saga/effects'
 import * as selectors from '../../selectors'
 import * as actions from './actions'
-import { getTransactions } from './helpers'
+import { getTransactions, tweakTxs } from './helpers'
 
+// Refreshing and tweak all transactions for a given address and network.
 export function* refreshTransactions() {
   const address = yield select(selectors.getAddress)
   const network = yield select(selectors.getNetworkId)
   if (address) {
     const transactions = yield call(getTransactions, address, network)
-    yield put(actions.refreshTransactions.success(transactions))
+    const tweakedTxs = yield call(tweakTxs, transactions, address, network)
+    yield put(actions.refreshTransactions.success(tweakedTxs))
   }
 }
 
+// Fetch and tweak all transactions for a given address and network.
 export function* fetchTransactions() {
   yield put(actions.fetchTransactions.request())
   try {
@@ -20,7 +23,8 @@ export function* fetchTransactions() {
     const network = yield select(selectors.getNetworkId)
     if (address) {
       const transactions = yield call(getTransactions, address, network)
-      yield put(actions.fetchTransactions.success(transactions))
+      const tweakedTxs = yield call(tweakTxs, transactions, address, network)
+      yield put(actions.fetchTransactions.success(tweakedTxs))
     } else {
       yield put(
         actions.fetchTransactions.failure(new Error('No address found.'))


### PR DESCRIPTION
* [x] Add some docs and refactor to `getTransaction`
* [x] Add `isRecipientContract` to detect ERC20 token transfers (i.e. using https://erc20faucet.com/), since the `isContractInteraction` function does not appear to detect them
* [x] Add support for detecting when transaction was sent to the original sender by using `tweakTxs` to add type `self-interaction`
* [x] Call `tweakTxs` for both `refreshTransactions` and `fetchTransactions` so that UI always shows the correct values
* [x] Removed the `direction` function as it didn't appear to be necessary (unnecessary complexity)

Note: Extends upon changes in PR https://github.com/mxc-foundation/mxc-wallet/commit/764576a580f19a74722b1bdb547920bafb2bd1dc
Note: Incorporates approaches that were adopted in PR https://github.com/mxc-foundation/mxc-wallet/pull/18/files, which was incorrectly using the 'master' branch instead of the 'develop' branch, so it didn't have any of
the changes that had already been made in PR https://github.com/mxc-foundation/mxc-wallet/commit/764576a580f19a74722b1bdb547920bafb2bd1dc

Screenshot: 

<img width="984" alt="Screenshot 2019-08-03 at 5 07 00 pm" src="https://user-images.githubusercontent.com/6226175/62413622-416ef200-b611-11e9-8757-b15dd9c69cc9.png">
